### PR TITLE
feat: cleaned up setup process, auto download weights to known location, refactor for .env configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,12 @@ output/
 
 logs/
 *.safetensors
+
+
+
+# FOR EXCLUSION OF DOWNLOADED WEIGHTS
+# Ignore everything in weights/
+weights/*
+
+# But don't ignore this file
+!weights/downloader.py

--- a/README.md
+++ b/README.md
@@ -42,29 +42,28 @@ source uso_env/bin/activate
 ## or
 conda create -n uso_env python=3.10 -y
 conda activate uso_env
+
+## install torch
+## recommended version:
+pip install torch==2.4.0 torchvision==0.19.0 --index-url https://download.pytorch.org/whl/cu124 
+
 ## then install the requirements by you need
 pip install -r requirements.txt # legacy installation command
 ```
 
-Then download checkpoints in one of the following ways:
-- **Suppose you already have some of the checkpoints**
+Then download checkpoints:
 ```bash
-# 1. download USO official checkpoints
+# 1. set up .env file
+cp example.env .env
+
+# 2. set your huggingface token in .env (open the file and change this value to your token)
+HF_TOKEN=your_huggingface_token_here
+
+#3. download the necessary weights (comment any weights you don't need)
 pip install huggingface_hub
-huggingface-cli download bytedance-research/USO --local-dir <YOU_SAVE_DIR> --local-dir-use-symlinks False
-
-# 2. Then set the environment variable for FLUX.1 base model
-export AE="YOUR_AE_PATH"
-export FLUX_DEV="YOUR_FLUX_DEV_PATH"
-export T5="YOUR_T5_PATH"
-export CLIP="YOUR_CLIP_PATH"
-# or export HF_HOME="YOUR_HF_HOME"
-
-# 3. Then set the environment variable for USO
-export LORA="<YOU_SAVE_DIR>/uso_flux_v1.0/dit_lora.safetensors"
-export PROJECTION_MODEL="<YOU_SAVE_DIR>/uso_flux_v1.0/projector.safetensors"
+python ./weights/downloader.py
 ```
-- Directly run the inference scripts, the checkpoints will be downloaded automatically by the `hf_hub_download` function in the code.
+- **IF YOU HAVE WEIGHTS, COMMENT OUT WHAT YOU DON'T NEED IN ./weights/downloader.py**
 
 ### ✍️ Inference
 * Start from the examples below to explore and spark your creativity. ✨
@@ -81,6 +80,9 @@ python inference.py --prompt "The woman gave an impassioned speech on the podium
 # for multi-style generation
 # please keep the first image path empty
 python inference.py --prompt "A handsome man." --image_paths "" "assets/gradio_examples/style3.webp" "assets/gradio_examples/style4.webp" --width 1024 --height 1024
+
+# for low vram:
+python inference.py --prompt "your propmt" --image_paths "your_image.jpg" --width 1024 --height 1024 --offload --model_type flux-dev-fp8 
 ```
 * You can also compare your results with the results in the `assets/gradio_examples` folder.
 

--- a/app.py
+++ b/app.py
@@ -17,6 +17,10 @@ import json
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+load_dotenv() 
+
+
 import gradio as gr
 import torch
 
@@ -100,17 +104,22 @@ def create_demo(
     device: str = "cuda" if torch.cuda.is_available() else "cpu",
     offload: bool = False,
 ):
+
+    # hf_download set to false to prevent download of weights
     pipeline = USOPipeline(
-        model_type, device, offload, only_lora=True, lora_rank=128, hf_download=True
+        model_type, device, offload, only_lora=True, lora_rank=128, hf_download=False
     )
     print("USOPipeline loaded successfully")
 
-    siglip_processor = SiglipImageProcessor.from_pretrained(
-        "google/siglip-so400m-patch14-384"
-    )
-    siglip_model = SiglipVisionModel.from_pretrained(
-        "google/siglip-so400m-patch14-384"
-    )
+
+
+
+    # ⚠️ Weights now load from local paths via .env instead of downloading
+    siglip_path = os.getenv("SIGLIP_PATH", "google/siglip-so400m-patch14-384")
+    siglip_processor = SiglipImageProcessor.from_pretrained(siglip_path)
+    siglip_model = SiglipVisionModel.from_pretrained(siglip_path)
+    
+    
     siglip_model.eval()
     siglip_model.to(device)
     pipeline.model.vision_encoder = siglip_model

--- a/example.env
+++ b/example.env
@@ -1,0 +1,23 @@
+# Hugging face token goes here:
+HF_TOKEN=your_huggingface_token_here
+
+# Core Flux weights
+FLUX_DEV=./weights/FLUX.1-dev/flux1-dev.safetensors
+FLUX_DEV_FP8=./weights/FLUX.1-dev/flux1-dev.safetensors
+AE=./weights/FLUX.1-dev/ae.safetensors
+
+# Text + vision encoders
+T5=./weights/t5-xxl
+CLIP=./weights/clip-vit-l14
+LORA=./weights/USO/uso_flux_v1.0/dit_lora.safetensors
+
+# USO LoRA + projector
+PROJECTION_MODEL=./weights/USO/uso_flux_v1.0/projector.safetensors
+SIGLIP_PATH=./weights/siglip
+
+
+# -------------------------------
+# Optional: Flux-Krea variant
+# -------------------------------
+# FLUX_DEV=./weights/FLUX.1-Krea-dev/flux1-krea-dev.safetensors
+# FLUX_DEV_FP8=./weights/FLUX.1-Krea-dev/flux1-krea-dev.safetensors

--- a/inference.py
+++ b/inference.py
@@ -16,6 +16,10 @@ import os
 import dataclasses
 from typing import Literal
 
+from dotenv import load_dotenv
+load_dotenv() 
+
+
 from accelerate import Accelerator
 from transformers import HfArgumentParser
 from PIL import Image
@@ -66,7 +70,7 @@ class InferenceArgs:
     ckpt_path: str | None = None
     use_siglip: bool = True
     instruct_edit: bool = False
-    hf_download: bool = True
+    hf_download: bool = False  # set to false, we must not auto download the weights (゜-゜) 
 
 
 def main(args: InferenceArgs):
@@ -76,12 +80,12 @@ def main(args: InferenceArgs):
     siglip_processor = None
     siglip_model = None
     if args.use_siglip:
-        siglip_processor = SiglipImageProcessor.from_pretrained(
-            "google/siglip-so400m-patch14-384"
-        )
-        siglip_model = SiglipVisionModel.from_pretrained(
-            "google/siglip-so400m-patch14-384"
-        )
+
+        # ⚠️ Weights now load from local paths via .env instead of downloading
+        siglip_path = os.getenv("SIGLIP_PATH", "google/siglip-so400m-patch14-384")
+        siglip_processor = SiglipImageProcessor.from_pretrained(siglip_path)
+        siglip_model = SiglipVisionModel.from_pretrained(siglip_path)
+
         siglip_model.eval()
         siglip_model.to(accelerator.device)
         print("SigLIP model loaded successfully")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ numpy==1.24.4
 onnxruntime-gpu
 # httpx==0.23.3
 git+https://github.com/openai/CLIP.git
---extra-index-url https://download.pytorch.org/whl/cu124
-torch==2.4.0
-torchvision==0.19.0
+# --extra-index-url https://download.pytorch.org/whl/cu124
+# torch==2.4.0
+# torchvision==0.19.0
+python-dotenv

--- a/weights/downloader.py
+++ b/weights/downloader.py
@@ -46,9 +46,9 @@ def download_siglip():
                       local_dir_use_symlinks=False)
 
 if __name__ == "__main__":
-    # download_flux()
+    download_uso()
+    download_flux()
     # download_flux_krea()
-    # download_uso()
-    # download_t5()
-    # download_clip()
+    download_t5()
+    download_clip()
     download_siglip()

--- a/weights/downloader.py
+++ b/weights/downloader.py
@@ -1,0 +1,54 @@
+from huggingface_hub import snapshot_download, hf_hub_download
+
+from dotenv import load_dotenv
+import os
+load_dotenv() 
+
+token = os.getenv("HF_TOKEN", None)
+
+
+def download_flux():
+    snapshot_download("black-forest-labs/FLUX.1-dev",
+                      allow_patterns=["flux1-dev.safetensors", "ae.safetensors"],
+                      local_dir="./weights/FLUX.1-dev",
+                      local_dir_use_symlinks=False,
+                      token=token)
+# optional 
+def download_flux_krea():
+    snapshot_download("black-forest-labs/FLUX.1-Krea-dev",
+                    allow_patterns=["flux1-krea-dev.safetensors"],
+                    local_dir="./weights/FLUX.1-Krea-dev",
+                    local_dir_use_symlinks=False,
+                    token=token)
+
+def download_uso():
+    snapshot_download("bytedance-research/USO",
+                      local_dir="./weights/USO",
+                      local_dir_use_symlinks=False)
+
+def download_t5():
+    for f in ["config.json", "tokenizer_config.json", "special_tokens_map.json",
+              "spiece.model", "pytorch_model.bin"]:
+        hf_hub_download("google/t5-v1_1-xxl", f, local_dir="./weights/t5-xxl",
+                        local_dir_use_symlinks=False)
+
+def download_clip():
+    for f in ["config.json", "merges.txt", "vocab.json",
+              "tokenizer_config.json", "special_tokens_map.json",
+              "pytorch_model.bin"]:
+        hf_hub_download("openai/clip-vit-large-patch14", f,
+                        local_dir="./weights/clip-vit-l14",
+                        local_dir_use_symlinks=False)
+
+def download_siglip():
+    snapshot_download("google/siglip-so400m-patch14-384",
+                      local_dir="./weights/siglip",
+                      local_dir_use_symlinks=False)
+
+if __name__ == "__main__":
+    # download_flux()
+    # download_flux_krea()
+    # download_uso()
+    # download_t5()
+    # download_clip()
+    download_siglip()


### PR DESCRIPTION
- requirements.txt no longer handles torch. addition of python-dotenv 
- .gitignore now ignores the weights folder while maintaining the downloader.py 
- inference.py and app.py no longer auto download. downloads should be managed by users via weights/downloader.py
- example.env for extremely simple set up while keep users token for huggingface secure 
- cleaned up README.md for streamlined set up. Addition of low VRAM config for inference script